### PR TITLE
Userguide + Benchmark --open argument (TODO)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webbrowser 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1210,6 +1211,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1392,7 @@ dependencies = [
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
+"checksum webbrowser 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21c311234fd1392a0071c1476cb7a4338dd2479e03e80e2328fbbf2db117b028"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ toml = "0.4.9"
 clap = "2.32.0"
 chrono = "0.4.6"
 reqwest = "0.9.5"
-
+webbrowser = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 # Cargo Advent of Code Helper
 
-This is a simple project that aims to be a helper for the [Advent of Code](https://adventofcode.com). 
+`cargo-aoc` is a simple CLI tool that aims to be a helper for the [Advent of Code](https://adventofcode.com). 
 
-Implement your solution. Let us do the rest.
+Implement your solution. Let us handle the rest.
 
 # Features
 * Input downloading 
 * Running your solution 
-* Benchmarking of your solution (WIP)
+* Automatic benchmarking of your solution using [Criterion](https://github.com/japaric/criterion.rs)
 
 # Getting started
 
 ## Install `cargo aoc`
 
+`cargo-aoc` is hosted as a binary on crates.io.
 Boot a terminal and install the program using `cargo install cargo-aoc`
 
-## Setting up
+## Setting up the CLI
 
 You will need to find your session token for the AoC in order for cargo-aoc to work. Thankfully, finding your token is easy since it is stored in your Browser's cookies. Open up the devtools of your browser, and then :
 
@@ -30,20 +31,134 @@ NOTE: If for some reason your token has changed, dont forget to change it back.
 
 `cargo aoc credentials` will show the currently stored user token
 
-# Input downloading 
+## Setting up the project
 
-`cargo aoc input` will download an input and store it in `input/{year}/{day}.txt`. 
+In order for `cargo-aoc` to work properly, you have to set the project up correctly. 
 
-Please note that by default, we're taking today's date as the argument. Of course, you can change this using : 
+If you get lost during the process, you can take [this example repository of AoC 2015](https://github.com/gobanos/advent-of-code-2015) as a template.
 
-`cargo aoc input -d {day} -y {year}`
+First, you must add a dependency on `aoc-runner` and `aoc-runner-derive` in your `Cargo.toml`.
+In your `src/lib.rs`, add **each day as a separate module** using `pub mod dayX.rs`.
+At the end of the `src/lib.rs`, you will have to use the macro aoc_lib!{ year = XXXX }, where XXXX is the 
+year of the AoC puzzles being solved.
+
+When implementing a solution for a day, you have to provide functions and tag them accordingly.
+A function is either a **solver** or a **generator**. 
+
+Those two types of functions are being executed and benchmarked seperately. Lets have a closer look : 
+
+### Generator functions
+
+Generators allows you to provide a custom type to the solver functions. Sometimes in AoC, you have to parse 
+an input and extract a logical structure out of it, before you can actually solve the problem. 
+
+Generator functions are tagged `#[aoc_generator(dayX)]`.
+
+Because examples are worth a thousand words, lets take a look at [Year 2015, Day 2](https://adventofcode.com/2015/day/2) : 
+
+From the puzzle's description, we know that `[we] have a list of the dimensions (length l, width w, and height h) of each present`, each present on one line, representend like so: `{L}x{W}x{H}`.
+
+We might want to first parse the input and extract logical `Gift` structs out of it, like: 
+
+```
+pub struct Gift {
+    l: u32,
+    w: u32,
+    h: u32
+}
+``` 
+
+In @Gobanos' reference implementation, we can see that he instead chose to settle for a custom type :
+`type Gift = (u32, u32, u32);`.
+
+Thus, writing a generator for `Gift`s is fairly simple: 
+
+```
+#[aoc_generator(day2)]
+pub fn input_generator(input: &str) -> Vec<Gift> {
+    input
+        .lines()
+        .map(|l| {
+            let mut gift = l.trim().split('x').map(|d| d.parse().unwrap());
+            (
+                gift.next().unwrap(),
+                gift.next().unwrap(),
+                gift.next().unwrap(),
+            )
+        }).collect()
+}
+``` 
+
+As you can see, generators take a &str type as an input, and outputs any type that you want, so you can then use it in `solver` functions.
+
+You can only have one generator per day, and its output will be used as the input of the solvers if they are tagged with the same day. 
+
+### Solver functions 
+
+Solver functions are typically your algorithms, they take any input type provided by a generator, and return any type that you want to use, provided that it implements the `Display` trait.
+
+Solver functions are tagged `#[aoc(day2, part1)]`. 
+Optionally, you can have multiple implementation for the same part of a day. You must then use a name to tag them correctly, for example : `#[aoc(day2, part1, for_loop)]`. 
+
+Following with the previous example, implementing a solver for the part one could be done like this :
+
+```
+#[aoc(day2, part1)]
+pub fn solve_part1(input: &[Gift]) -> u32 {
+    input
+        .iter()
+        .map(|&(l, w, h)| {
+            let (s1, s2) = smallest_side((l, w, h));
+            2 * l * w + 2 * w * h + 2 * h * l + s1 * s2
+        })
+        .sum()
+}
+``` 
+
+Notice how we're taking the `Gift`s generated previously, and using Rust's iterators to solve the problem efficiently, all the while keeping the code maintainable. 
+
+The output of this particular solver is an `u32`, which of course implements `Display`.
+When running your solution using `cargo aoc`, said result will then get printed in the console, along with other informations about execution time.
+
+# Downloading your input manually
+
+`cargo aoc input` will download an input and store it in `input/{year}/day_{day}.txt`. 
+
+Please note that by default, we're taking today's date as the argument. Of course, you can change this using : `cargo aoc input -d {day} -y {year}`
 
 # Running your solution
 
-`cargo aoc` will run your last implemented day, with your own input.
+`cargo aoc` will run the latest implemented day, downloading your input beforehand. It will show you the result, and a short summary of how well it did perform.
 
-Need to run an older puzzle, or only a part ? `cargo aoc -d {day} -p {part}` !
+Example output on my Chromebook, running [@Gobanos' AOC2015](https://github.com/gobanos/advent-of-code-2015) : 
+```
+[olivier@olivier-pc advent-of-code-2015]$ cargo aoc
+    Finished dev [unoptimized + debuginfo] target(s) in 0.12s
+   Compiling aoc-autobuild v0.1.0 (/home/olivier/Workspace/Rust/advent-of-code-2015/target/aoc/aoc-autobuild)
+    Finished release [optimized] target(s) in 0.87s
+     Running `target/release/aoc-autobuild`
+AOC 2015
+Day 5 - Part 1 : 238
+        generator: 18.122µs,
+        runner: 420.958µs
+
+Day 5 - Part 2 : 69
+        generator: 5.499µs,
+        runner: 1.142373ms
+```
+
+If you want to run an older puzzle, or only a specific part, specify those using `cargo aoc -d {day} -p {part}`.
 
 # Benchmarking your solution
 
-Just use `cargo aoc bench`, in the same way `cargo aoc` work !
+Benchmarking is powered by [Criterion](https://github.com/japaric/criterion.rs). Use `cargo aoc bench` to launch the benchmarks, just like you would use `cargo aoc`.
+
+Benchmarks for each days are then generated in `target/aoc/aoc-autobench/target/criterion`.
+
+You can open the benchmark automatically in your Browser afterwards, using `cargo aoc bench -o` 
+
+Soon(tm), you will also be able to use our (free) online platform, to compare your results with those of the community.
+
+------
+
+Happy Advent of Code !   

--- a/src/app.rs
+++ b/src/app.rs
@@ -157,7 +157,8 @@ impl AOCApp {
         let cargo_content = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/template/Cargo-run.toml.tpl"
-        )).replace("{CRATE_NAME}", &pm.name);
+        ))
+        .replace("{CRATE_NAME}", &pm.name);
 
         let template = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
@@ -201,7 +202,8 @@ impl AOCApp {
         let main_content = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/template/src/main.rs.tpl"
-        )).replace("{CRATE_SLUG}", &pm.slug)
+        ))
+        .replace("{CRATE_SLUG}", &pm.slug)
         .replace("{YEAR}", &day_parts.year.to_string())
         .replace("{BODY}", &body);
 
@@ -246,7 +248,8 @@ impl AOCApp {
         let cargo_content = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/template/Cargo-bench.toml.tpl"
-        )).replace("{CRATE_NAME}", &pm.name);
+        ))
+        .replace("{CRATE_NAME}", &pm.name);
 
         let bench_tpl = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
@@ -302,7 +305,8 @@ impl AOCApp {
                                         } else {
                                             format!("day{}_part{}", dp.day.0, dp.part.0)
                                         },
-                                    ).replace("{INPUT}", &format!("{}/day{}.txt", year, dp.day.0))
+                                    )
+                                    .replace("{INPUT}", &format!("{}/day{}.txt", year, dp.day.0))
                                     .replace(
                                         "{NAME}",
                                         if let Some(n) = &dp.name {
@@ -310,10 +314,13 @@ impl AOCApp {
                                         } else {
                                             "(default)"
                                         },
-                                    ).replace("{PART_NAME}", &part_name)
-                            }).collect::<String>(),
+                                    )
+                                    .replace("{PART_NAME}", &part_name)
+                            })
+                            .collect::<String>(),
                     )
-            }).collect();
+            })
+            .collect();
 
         if body.is_empty() {
             Err("No matching day & part found")?;
@@ -332,7 +339,8 @@ impl AOCApp {
         fs::write(
             "target/aoc/aoc-autobench/benches/aoc_benchmark.rs",
             &main_content,
-        ).expect("failed to write src/aoc_benchmark.rs");
+        )
+        .expect("failed to write src/aoc_benchmark.rs");
 
         let status = process::Command::new("cargo")
             .args(&["bench"])
@@ -344,6 +352,11 @@ impl AOCApp {
 
         if !status.success() {
             process::exit(status.code().unwrap_or(-1));
+        }
+
+        if args.is_present("open") {
+            // TODO: Handle webbrowser opening of the benchmarks...
+            //webbrowser::open("target/aoc/aoc-autobench/target/criterion")
         }
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ extern crate clap;
 /// ... Tokio is overkill for the scope of this project.
 extern crate reqwest;
 extern crate toml;
+extern crate webbrowser;
 
 mod app;
 mod credentials;
@@ -28,12 +29,14 @@ fn main() {
                 .short("d")
                 .help("Specifies the day. Defaults to last implemented.")
                 .takes_value(true),
-        ).arg(
+        )
+        .arg(
             Arg::with_name("part")
                 .short("p")
                 .help("Specifies the part. Defaults to both parts.")
                 .takes_value(true),
-        ).subcommand(
+        )
+        .subcommand(
             SubCommand::with_name("bench")
                 .about("Benchmark your solutions")
                 .arg(
@@ -41,13 +44,20 @@ fn main() {
                         .short("d")
                         .help("Specifies the day. Defaults to last implemented.")
                         .takes_value(true),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("part")
                         .short("p")
                         .help("Specifies the part. Defaults to both parts.")
                         .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("open")
+                        .short("o")
+                        .help("Opens the benchmark information in the browser"),
                 ),
-        ).subcommand(
+        )
+        .subcommand(
             SubCommand::with_name("credentials")
                 .about("Manage your AOC credentials information")
                 .arg(
@@ -56,7 +66,8 @@ fn main() {
                         .help("Sets the session cookie")
                         .takes_value(true),
                 ),
-        ).subcommand(
+        )
+        .subcommand(
             SubCommand::with_name("input")
                 .about("Get the input for a specified date")
                 .arg(
@@ -64,13 +75,15 @@ fn main() {
                         .short("d")
                         .help("Specifies the day. Defaults to today's date.")
                         .takes_value(true),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("year")
                         .short("y")
                         .help("Specifies the year. Defaults to the current year.")
                         .takes_value(true),
                 ),
-        ).get_matches();
+        )
+        .get_matches();
 
     // Creates an AOCApp that we'll use to launch actions (commands)
     let app = AOCApp::new();


### PR DESCRIPTION
+ Adds a dependency to [webbrowser](https://crates.io/crates/webbrowser) - supposedly this can open an URL. I'm assuming that it also handles local files.
+ CLAP CLI Args "open" setup for `cargo aoc bench`
+ Corrects some sentences on the README.md
+ Adds a full userguide on how to use the tool :+1:

Once --open is implemented, everything seems ready to be used & posted on Reddit ! :)