### PR TITLE
input: create folders if they don't exist

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -77,8 +77,7 @@ impl AOCApp {
                     let dir = date.directory();
                     // Creates the file-tree to store inputs
                     // TODO: Maybe use crate's infos to get its root in the filesystem ? 
-                    fs::create_dir("input").expect("Could not create input directory");
-                    fs::create_dir(&dir).expect(&format!("Could not create input directory: {}", dir));
+                    fs::create_dir_all(&dir).expect(&format!("Could not create input directory: {}", dir));
 
                     // Gets the body from the response and outputs everything to a file
                     let body = response.text().expect("Could not read content from input");


### PR DESCRIPTION
Command `cargo aoc input` failed on second run for the same year, as it was
unable to create the folders which already existed. fs::create_dir_all creates
the whole folder structure in a single command and does not fail if the
folder structure already exists.

Signed-off-by: Petre Eftime <petre.eftime@gmail.com>