### PR TITLE
Better error messages + Cleaner macro attributes parsing using Darling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,7 @@ name = "aoc-runner-derive"
 version = "0.2.2"
 dependencies = [
  "aoc-runner-internal 0.1.0",
+ "darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -298,6 +299,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +537,11 @@ dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "idna"
@@ -1174,6 +1212,11 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1621,9 @@ dependencies = [
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+"checksum darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+"checksum darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+"checksum darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
@@ -1601,6 +1647,7 @@ dependencies = [
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
+"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a61202fbe46c4a951e9404a720a0180bcf3212c750d735cb5c4ba4dc551299f3"
@@ -1679,6 +1726,7 @@ dependencies = [
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"

--- a/aoc-runner-derive/Cargo.toml
+++ b/aoc-runner-derive/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
+darling = "0.10.2"
 syn = { version = "1.0.5", features = ["extra-traits"] }
 quote = "1.0.2"
 proc-macro2 = "1.0.5"

--- a/aoc-runner-derive/src/lib.rs
+++ b/aoc-runner-derive/src/lib.rs
@@ -29,10 +29,10 @@ thread_local! {
     static AOC_RUNNER: Map = Map::new();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct DayWrapper(u8);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct PartWrapper(u8);
 
 impl FromMeta for DayWrapper {
@@ -66,6 +66,16 @@ impl FromMeta for PartWrapper {
 struct AocArgs {
     day: DayWrapper,
     part: PartWrapper,
+    #[darling(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Clone, FromMeta)]
+/// The arguments of an AOC Attribute Macro usage
+struct AocGeneratorArgs {
+    day: DayWrapper,
+    #[darling(default)]
+    part: Option<PartWrapper>,
     #[darling(default)]
     name: Option<String>,
 }

--- a/aoc-runner-derive/src/lib.rs
+++ b/aoc-runner-derive/src/lib.rs
@@ -2,6 +2,8 @@
 
 extern crate aoc_runner_internal;
 extern crate core;
+#[macro_use]
+extern crate darling;
 extern crate proc_macro;
 extern crate proc_macro2;
 extern crate quote;
@@ -16,12 +18,56 @@ mod utils;
 
 use crate::map::Map;
 use crate::utils::is_rls;
+use aoc_runner_internal::{Day, Part};
+use darling::FromMeta;
 use proc_macro as pm;
 use proc_macro2 as pm2;
 use quote::quote;
+use syn::Lit;
 
 thread_local! {
     static AOC_RUNNER: Map = Map::new();
+}
+
+#[derive(Debug)]
+struct DayWrapper(u8);
+
+#[derive(Debug)]
+struct PartWrapper(u8);
+
+impl FromMeta for DayWrapper {
+    fn from_value(value: &Lit) -> Result<Self, darling::error::Error> {
+        let inner = u8::from_value(value)?;
+        Ok(DayWrapper(inner))
+    }
+}
+
+impl Into<Day> for DayWrapper {
+    fn into(self) -> Day {
+        Day(self.0)
+    }
+}
+
+impl Into<Part> for PartWrapper {
+    fn into(self) -> Part {
+        Part(self.0)
+    }
+}
+
+impl FromMeta for PartWrapper {
+    fn from_value(value: &Lit) -> Result<Self, darling::error::Error> {
+        let inner = u8::from_value(value)?;
+        Ok(PartWrapper(inner))
+    }
+}
+
+#[derive(Debug, FromMeta)]
+/// The arguments of an AOC Attribute Macro usage
+struct AocArgs {
+    day: DayWrapper,
+    part: PartWrapper,
+    #[darling(default)]
+    name: Option<String>,
 }
 
 #[proc_macro_attribute]
@@ -47,14 +93,6 @@ thread_local! {
 ///
 /// [generator]: attr.aoc_generator.html
 pub fn aoc(args: pm::TokenStream, input: pm::TokenStream) -> pm::TokenStream {
-    if is_rls() {
-        let input: pm2::TokenStream = input.into();
-        return pm::TokenStream::from(quote! {
-            #[allow(unused)]
-            #input
-        });
-    }
-
     runner::runner_impl(args, input)
 }
 

--- a/examples/aoc-2018/src/day1.rs
+++ b/examples/aoc-2018/src/day1.rs
@@ -8,12 +8,12 @@ fn parse_input_day1(input: &str) -> Result<Vec<i32>, ParseIntError> {
     input.lines().map(|l| l.parse()).collect()
 }
 
-#[aoc(day1, part1)]
+#[aoc(day = "1", part = "1")]
 fn part1(freqs: &[i32]) -> i32 {
     freqs.iter().sum()
 }
 
-#[aoc(day1, part2)]
+#[aoc(day = "1", part = "2")]
 fn part2(freqs: &[i32]) -> i32 {
     let mut reached = HashSet::new();
     let mut sum = 0;
@@ -32,7 +32,7 @@ fn part2(freqs: &[i32]) -> i32 {
     sum
 }
 
-#[aoc(day1, part2, Fnv)]
+#[aoc(day = "1", part = "2", name = "Fnv")]
 fn part2_fnv(freqs: &[i32]) -> i32 {
     let mut reached = FnvHashSet::default();
     let mut sum = 0;

--- a/examples/aoc-2018/src/day1.rs
+++ b/examples/aoc-2018/src/day1.rs
@@ -3,7 +3,7 @@ use fnv::FnvHashSet;
 use std::collections::HashSet;
 use std::num::ParseIntError;
 
-#[aoc_generator(day1)]
+#[aoc_generator(day = "1")]
 fn parse_input_day1(input: &str) -> Result<Vec<i32>, ParseIntError> {
     input.lines().map(|l| l.parse()).collect()
 }

--- a/examples/aoc-2018/src/day2.rs
+++ b/examples/aoc-2018/src/day2.rs
@@ -2,7 +2,7 @@ use aoc_runner_derive::aoc;
 use fnv::FnvHashMap;
 use std::collections::HashMap;
 
-#[aoc(day2, part1)]
+#[aoc(day = "2", part = "1")]
 fn part1(input: &str) -> u32 {
     let (nb_double, nb_triple) = input
         .lines()
@@ -26,7 +26,7 @@ fn part1(input: &str) -> u32 {
     nb_double * nb_triple
 }
 
-#[aoc(day2, part1, Fnv)]
+#[aoc(day = "2", part = "1", name = "Fnv")]
 fn part1_fnv(input: &str) -> u32 {
     let (nb_double, nb_triple) = input
         .lines()
@@ -51,7 +51,7 @@ fn part1_fnv(input: &str) -> u32 {
     nb_double * nb_triple
 }
 
-#[aoc(day2, part2)]
+#[aoc(day = "2", part = "2")]
 fn part2(input: &str) -> String {
     let lines = input.lines();
 

--- a/examples/aoc-2018/src/day3.rs
+++ b/examples/aoc-2018/src/day3.rs
@@ -41,7 +41,7 @@ impl Rectangle {
     }
 }
 
-#[aoc_generator(day3)]
+#[aoc_generator(day = "3")]
 fn parse(input: &str) -> Result<Vec<Claim>, Box<dyn Error>> {
     input
         .lines()

--- a/examples/aoc-2018/src/day3.rs
+++ b/examples/aoc-2018/src/day3.rs
@@ -75,7 +75,7 @@ fn parse(input: &str) -> Result<Vec<Claim>, Box<dyn Error>> {
         .collect()
 }
 
-#[aoc(day3, part1)]
+#[aoc(day = "3", part = "1")]
 fn part1(claims: &[Claim]) -> usize {
     let mut overlaps = FnvHashSet::default();
 
@@ -94,7 +94,7 @@ fn part1(claims: &[Claim]) -> usize {
     overlaps.len()
 }
 
-#[aoc(day3, part2)]
+#[aoc(day = "3", part = "2")]
 fn part2(claims: &[Claim]) -> Option<u32> {
     claims.iter().find_map(|c| {
         if claims

--- a/examples/aoc-2018/src/day4.rs
+++ b/examples/aoc-2018/src/day4.rs
@@ -78,7 +78,7 @@ impl FromStr for Action {
     }
 }
 
-#[aoc_generator(day4)]
+#[aoc_generator(day = "4")]
 fn parse(input: &str) -> Result<Vec<Record>, Error> {
     let mut records = input
         .lines()

--- a/examples/aoc-2018/src/day4.rs
+++ b/examples/aoc-2018/src/day4.rs
@@ -127,7 +127,7 @@ fn build_map(records: &[Record]) -> Result<HashMap<GuardId, GuardRecord>, &'stat
     Ok(map)
 }
 
-#[aoc(day4, part1)]
+#[aoc(day = "4", part = "1")]
 fn part1(records: &[Record]) -> Result<u32, &'static str> {
     let map = build_map(records)?;
 
@@ -152,7 +152,7 @@ fn part1(records: &[Record]) -> Result<u32, &'static str> {
     Ok(guard * min)
 }
 
-#[aoc(day4, part2)]
+#[aoc(day = "4", part = "2")]
 fn part2(records: &[Record]) -> Result<u32, &'static str> {
     let map = build_map(records)?;
 

--- a/examples/aoc-2018/src/day5.rs
+++ b/examples/aoc-2018/src/day5.rs
@@ -9,7 +9,7 @@ fn diff(a: u8, b: u8) -> u8 {
     u8::max(a, b) - u8::min(a, b)
 }
 
-#[aoc_generator(day5)]
+#[aoc_generator(day = "5")]
 fn generator(input: &str) -> &[u8] {
     input.as_bytes()
 }

--- a/examples/aoc-2018/src/day5.rs
+++ b/examples/aoc-2018/src/day5.rs
@@ -14,24 +14,24 @@ fn generator(input: &str) -> &[u8] {
     input.as_bytes()
 }
 
-#[aoc(day5, part1)]
+#[aoc(day = "5", part = "1")]
 fn part1(input: &[u8]) -> usize {
     reduce(input)
 }
 
-#[aoc(day5, part2)]
+#[aoc(day = "5", part = "2")]
 fn part2(input: &[u8]) -> Option<usize> {
     (b'A'..=b'Z')
         .map(|c| reduce(input.iter().filter(|&&a| a != c && a != c + DIFF)))
         .min()
 }
 
-#[aoc(day5, part1, Stack)]
+#[aoc(day = "5", part = "1", name = "Stack")]
 fn part1_stack(input: &[u8]) -> usize {
     stack(input)
 }
 
-#[aoc(day5, part2, Stack)]
+#[aoc(day = "5", part = "2", name = "Stack")]
 fn part2_stack(input: &[u8]) -> Option<usize> {
     (b'A'..=b'Z')
         .map(|c| stack(input.iter().filter(|&&a| a != c && a != c + DIFF)))

--- a/examples/aoc-2018/src/day6.rs
+++ b/examples/aoc-2018/src/day6.rs
@@ -54,7 +54,7 @@ fn all_points(tl: Point, br: Point) -> impl Iterator<Item = Point> {
     (tl.x..=br.x).flat_map(move |x| (tl.y..=br.y).map(move |y| Point { x, y }))
 }
 
-#[aoc_generator(day6)]
+#[aoc_generator(day = "6")]
 fn parse(input: &str) -> Result<Vec<Point>, Box<dyn Error>> {
     input.lines().map(Point::from_str).collect()
 }

--- a/examples/aoc-2018/src/day6.rs
+++ b/examples/aoc-2018/src/day6.rs
@@ -59,7 +59,7 @@ fn parse(input: &str) -> Result<Vec<Point>, Box<dyn Error>> {
     input.lines().map(Point::from_str).collect()
 }
 
-#[aoc(day6, part1)]
+#[aoc(day = "6", part = "1")]
 fn part1(points: &[Point]) -> Option<usize> {
     let (tl, br) = bounds(points);
 
@@ -114,7 +114,7 @@ fn part1(points: &[Point]) -> Option<usize> {
     max_area.map(|(_, size)| size)
 }
 
-#[aoc(day6, part2)]
+#[aoc(day = "6", part = "2")]
 fn part2(points: &[Point]) -> Option<usize> {
     part2_internal(points, 10_000)
 }

--- a/examples/aoc-2018/src/day7.rs
+++ b/examples/aoc-2018/src/day7.rs
@@ -66,7 +66,7 @@ fn parse(input: &str) -> Result<Graph<Step, ()>, &'static str> {
     Ok(graph.into_graph())
 }
 
-#[aoc(day7, part1)]
+#[aoc(day = "7", part = "1")]
 fn part1(graph: &Graph<Step, ()>) -> Result<String, FromUtf8Error> {
     let mut remaining = graph.clone();
 
@@ -84,7 +84,7 @@ fn part1(graph: &Graph<Step, ()>) -> Result<String, FromUtf8Error> {
     }
 }
 
-#[aoc(day7, part2)]
+#[aoc(day = "7", part = "2")]
 fn part2(graph: &Graph<Step, ()>) -> u32 {
     part2_internal(graph, 5, 60)
 }

--- a/examples/aoc-2018/src/day7.rs
+++ b/examples/aoc-2018/src/day7.rs
@@ -48,7 +48,7 @@ impl FromStr for Instruction {
     }
 }
 
-#[aoc_generator(day7)]
+#[aoc_generator(day = "7")]
 fn parse(input: &str) -> Result<Graph<Step, ()>, &'static str> {
     use petgraph::graphmap::DiGraphMap;
 

--- a/examples/aoc-2018/src/day8.rs
+++ b/examples/aoc-2018/src/day8.rs
@@ -47,7 +47,7 @@ impl Node {
     }
 }
 
-#[aoc_generator(day8)]
+#[aoc_generator(day = "8")]
 fn parse(input: &str) -> Option<Node> {
     Node::from_iter(&mut input.split_whitespace().map(|s| s.parse().unwrap()))
 }

--- a/examples/aoc-2018/src/day8.rs
+++ b/examples/aoc-2018/src/day8.rs
@@ -52,12 +52,12 @@ fn parse(input: &str) -> Option<Node> {
     Node::from_iter(&mut input.split_whitespace().map(|s| s.parse().unwrap()))
 }
 
-#[aoc(day8, part1)]
+#[aoc(day = "8", part = "1")]
 fn part1(root: &Node) -> Data {
     root.checksum()
 }
 
-#[aoc(day8, part2)]
+#[aoc(day = "8", part = "2")]
 fn part2(root: &Node) -> Data {
     root.value()
 }


### PR DESCRIPTION
This PR refactors the parsing of macro attributes (both `aoc` and `aoc_generator` ) to use the `darling` helper crate, allowing for : 
 * Cleaner implementation (using actual struct for arguments)
 * Better error messages for the user

We might need to remove unused functions. 