### PR TITLE
Add note in the README about upgrading `cargo-aoc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Implement your solution. Let us handle the rest.
 `cargo-aoc` is hosted as a binary on crates.io.
 Boot a terminal and install the program using `cargo install cargo-aoc`
 
+If you installed `cargo-aoc` in a previous year, it may be out of date now and this 
+will cause build errors because of a version mismatch if you use the latest version of the `aoc-runner` and `aoc-runner-derive` below. If that's the case, then update it with `cargo install cargo-aoc --force`.
+
 ## Setting up the CLI
 
 You will need to find your session token for the AoC in order for cargo-aoc to work. Thankfully, finding your token is easy since it is stored in your Browser's cookies. Open up the devtools of your browser, and then :


### PR DESCRIPTION
I ran into build errors trying to get set up. It turns out I had a previous version of `cargo-aoc` installed, which caused a version mismatch since this tooling needs to be in sync with the crate dependencies.

This change adds a note to the README to hopefully keep other people from running into the same problem.