### PR TITLE
Show nice error message instead of huge debug representation of it

### DIFF
--- a/aoc-runner-derive/src/out.rs
+++ b/aoc-runner-derive/src/out.rs
@@ -165,7 +165,7 @@ fn body(infos: &DayParts, lib: Option<pm2::Ident>) -> pm2::TokenStream {
                     dp.day.as_u8(), dp.part.as_u8(), n
                 ),
                 format!(
-                    "Day {} - Part {} - {}: FAILED while {{}}:\n{{:#?}}\n",
+                    "Day {} - Part {} - {}: FAILED while {{}}:\n{{:?}}\n",
                     dp.day.as_u8(), dp.part.as_u8(), n
                 )
             )
@@ -176,7 +176,7 @@ fn body(infos: &DayParts, lib: Option<pm2::Ident>) -> pm2::TokenStream {
                     dp.day.as_u8(), dp.part.as_u8()
                 ),
                 format! (
-                    "Day {} - Part {}: FAILED while {{}}:\n{{:#?}}\n",
+                    "Day {} - Part {}: FAILED while {{}}:\n{{:?}}\n",
                     dp.day.as_u8(), dp.part.as_u8()
                 )
             )

--- a/cargo-aoc/template/src/runner.rs.tpl
+++ b/cargo-aoc/template/src/runner.rs.tpl
@@ -11,9 +11,9 @@
                         let final_time = Instant::now();
                         println!("{RUNNER_DISPLAY} : {}\n\tgenerator: {:?},\n\trunner: {:?}\n", result, (inter_time - start_time), (final_time - inter_time));
                     },
-                    Err(e) => eprintln!("{RUNNER_DISPLAY} : FAILED while running :\n{:#?}\n", e)
+                    Err(e) => eprintln!("{RUNNER_DISPLAY} : FAILED while running :\n{:?}\n", e)
                 }
             },
-            Err(e) => eprintln!("{RUNNER_DISPLAY} : FAILED while generating :\n{:#?}\n", e)
+            Err(e) => eprintln!("{RUNNER_DISPLAY} : FAILED while generating :\n{:?}\n", e)
         }
     }


### PR DESCRIPTION
The motivation: I'm returning anyhow::Result<i32> from the solver function
and https://docs.rs/anyhow/1.0.25/anyhow/struct.Error.html#display-representations
explains the difference

I can try to add a configuration parameter in some way, if you wish