### PR TITLE
Add build only command for debugging support

### DIFF
--- a/cargo-aoc/src/app.rs
+++ b/cargo-aoc/src/app.rs
@@ -135,7 +135,7 @@ impl AOCApp {
         Ok(())
     }
 
-    pub fn execute_default(&self, args: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
+    fn generate_subproject(&self, args: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
         let day: Option<Day> = args
             .value_of("day")
             .map(|d| d.parse().expect("Failed to parse day"));
@@ -221,8 +221,12 @@ impl AOCApp {
         fs::write("target/aoc/aoc-autobuild/src/main.rs", &main_content)
             .expect("failed to write src/main.rs");
 
+        Ok(())
+    }
+
+    fn cargo_exec(args: &[&str]) {
         let status = process::Command::new("cargo")
-            .args(&["run", "--release"])
+            .args(args)
             .current_dir("target/aoc/aoc-autobuild")
             .spawn()
             .expect("Failed to run cargo")
@@ -232,6 +236,18 @@ impl AOCApp {
         if !status.success() {
             process::exit(status.code().unwrap_or(-1));
         }
+    }
+
+    pub fn execute_build(&self, args: &ArgMatches) -> Result<(), Box<dyn error::Error>>  {
+        self.generate_subproject(args)?;
+        Self::cargo_exec(&["build"]);
+
+        Ok(())
+    }
+
+    pub fn execute_default(&self, args: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
+        self.generate_subproject(args)?;
+        Self::cargo_exec(&["run", "--release"]);
 
         Ok(())
     }

--- a/cargo-aoc/src/main.rs
+++ b/cargo-aoc/src/main.rs
@@ -112,6 +112,28 @@ fn main() {
                         .takes_value(true),
                 ),
         )
+        .subcommand(
+            SubCommand::with_name("build")
+                .about("Builds the subproject for debugging purposes")
+                .arg(
+                    Arg::with_name("day")
+                        .short("d")
+                        .help("Specifies the day. Defaults to today's date.")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("year")
+                        .short("y")
+                        .help("Specifies the year. Defaults to the current year.")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("input")
+                        .short("i")
+                        .help("Use an alternate input file.")
+                        .takes_value(true),
+                )
+        )
         .get_matches();
 
     // Creates an AOCApp that we'll use to launch actions (commands)
@@ -122,14 +144,20 @@ fn main() {
         ("input", Some(m)) => app.execute_input(&m),
         ("bench", Some(m)) => {
             if let Err(e) = app.execute_bench(&m) {
-                eprintln!("An error occurs : {}", e.description());
+                eprintln!("An error occurs : {}", e);
+                std::process::exit(-1);
+            }
+        }
+        ("build", Some(m)) => {
+            if let Err(e) = app.execute_build(&m) {
+                eprintln!("An error occurs : {}", e);
                 std::process::exit(-1);
             }
         }
         (c, Some(_)) => panic!("Unknown command `{}`", c),
         _ => {
             if let Err(e) = app.execute_default(&matches) {
-                eprintln!("An error occurs : {}", e.description());
+                eprintln!("An error occurs : {}", e);
                 std::process::exit(-1);
             }
         }


### PR DESCRIPTION
resolves #64 

Adds an `aoc build` command which generates and builds the subproject, without executing it. This way you can launch the aoc-autobuild executable with a debugger.

For example, in vscode using these two config files and the CodeLLDB plugin:
```jsonc
// .vscode/tasks.json
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "aoc",
            "type": "shell",
            "command": "cargo aoc build"
        }
    ]
}
```
```jsonc
// .vscode/launch.json
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "lldb",
            "request": "launch",
            "name": "Debug AOC",
            "preLaunchTask": "aoc",
            "program": "${workspaceFolder}/target/aoc/aoc-autobuild/target/debug/aoc-autobuild",
            "sourceLanguages": ["rust"],
            "args": [],
            "cwd": "${workspaceFolder}"
        }
    ]
}
```