### PR TITLE
Remove unnecessary dependencies on serde.

### DIFF
--- a/aoc-runner-internal/Cargo.toml
+++ b/aoc-runner-internal/Cargo.toml
@@ -8,6 +8,3 @@ repository = "https://github.com/gobanos/aoc-runner-internal"
 edition = "2018"
 
 [dependencies]
-serde = "1.0.101"
-serde_derive = "1.0.101"
-serde_json = "1.0.41"

--- a/aoc-runner-internal/src/lib.rs
+++ b/aoc-runner-internal/src/lib.rs
@@ -1,8 +1,8 @@
-use serde::export::fmt::Error;
-use serde::export::Formatter;
 use std::cmp::Ordering;
 use std::convert::TryFrom;
 use std::fmt::Display;
+use std::fmt::Error;
+use std::fmt::Formatter;
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;


### PR DESCRIPTION
Serde no longer has a public (hidden) export module.
The `fmt` module in serde was a re-export of core/std fmt. Let's use that one directly instead.
