### PR TITLE
Fix running from subdir in workspace

### DIFF
--- a/cargo-aoc/template/Cargo-bench.toml.tpl
+++ b/cargo-aoc/template/Cargo-bench.toml.tpl
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "aoc-autobench"
 version = "0.3.0"

--- a/cargo-aoc/template/Cargo-run.toml.tpl
+++ b/cargo-aoc/template/Cargo-run.toml.tpl
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "aoc-autobuild"
 version = "0.3.0"


### PR DESCRIPTION
When run in a subdir within a workspace, the following error appears:

```
error: current package believes it's in a workspace when it's not:
current:   C:\Users\jmerdich\workspace\aoc\2021\target\aoc\aoc-autobuild\Cargo.toml
workspace: C:\Users\jmerdich\workspace\aoc\Cargo.toml

this may be fixable by adding `2021\target\aoc\aoc-autobuild` to the `workspace.members` array of the manifest located at: C:\Users\jmerdich\workspace\aoc\Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
```

Tweak the templates so cargo knows the autogenerated projects are not
meant for the workspace. Running in the root of a workspace is still not
supported.