### PR TITLE
Add a panic message if runner is missing return type

### DIFF
--- a/aoc-runner-derive/src/runner.rs
+++ b/aoc-runner-derive/src/runner.rs
@@ -63,7 +63,7 @@ pub fn runner_impl(args: pm::TokenStream, input: pm::TokenStream) -> pm::TokenSt
     let out_t = if let ReturnType::Type(_, p) = input.sig.output {
         p
     } else {
-        panic!()
+        panic!("runners must return a value")
     };
 
     let (special_type, out_t) = if let Some((ty, inner)) = extract_result(&*out_t) {


### PR DESCRIPTION
Ran into this panic and got very confused, just adds a message to prevent future confusion 