### PR TITLE
fix bug in arguments when running with cargo

### DIFF
--- a/cargo-aoc/src/main.rs
+++ b/cargo-aoc/src/main.rs
@@ -100,7 +100,8 @@ pub struct Input {
 }
 
 fn main() {
-    let cli = Cli::parse();
+    let args = std::env::args().enumerate().filter(|(n, arg)| *n != 1 || arg != "aoc").map(|(_, arg)| arg);
+    let cli = Cli::parse_from(args);
 
     let Some(subcommand) = cli.subcmd else {
         return execute_default(&cli).unwrap();


### PR DESCRIPTION
Running cargo aoc and not cargo-aoc without any arguments produces difference reqults from my testing. Think resent changes to clap PR introduced this. This PR just removed aoc from the second argument if it exsists.
![image](https://github.com/gobanos/cargo-aoc/assets/17087998/7676b3e6-0e10-4f15-806b-7dcb1ce3c05a)
