### PR TITLE
Update cargo-aoc reqwest dependency

### DIFF
--- a/cargo-aoc/Cargo.toml
+++ b/cargo-aoc/Cargo.toml
@@ -16,7 +16,7 @@ aoc-runner-internal = "0.1.0"
 toml = "0.8.8"
 chrono = "0.4.31"
 chrono-tz = "0.8.4"
-reqwest = { version = "0.11.22", default-features = false, features = ["blocking", "rustls"] }
+reqwest = { version = "0.11.22", features = ["blocking", "rustls"] }
 webbrowser = "0.8.12"
 directories = "5.0.1"
 clap = { version = "4.4.8", features = ["derive"] }


### PR DESCRIPTION
Default features are needed for request to use tls/https see: https://github.com/seanmonstar/reqwest/issues/1430


Locally all downloads would fail with:
`error sending request for url (https://adventofcode.com/2023/day/1/input): error trying to connect: invalid URL, scheme is not http`

Download succeeded with dependency update.