### PR TITLE
add boilerplate for tests + move template to a new file

### DIFF
--- a/cargo-aoc/src/app.rs
+++ b/cargo-aoc/src/app.rs
@@ -41,9 +41,9 @@ pub fn execute_credentials(args: &Credentials) {
 /// Executes the "input" subcommand of the app
 pub fn execute_input(args: &Input) -> Result<(), Box<dyn Error>> {
     // Gets the token or exit if it's not referenced.
-    let token = CredentialsManager::new().get_session_token().expect(
-        "Error: you need to setup your AOC token using \"cargo aoc credentials {token}\"",
-    );
+    let token = CredentialsManager::new()
+        .get_session_token()
+        .expect("Error: you need to setup your AOC token using \"cargo aoc credentials {token}\"");
 
     let pm = ProjectManager::new()?;
 

--- a/cargo-aoc/template/src/day.rs.tpl
+++ b/cargo-aoc/template/src/day.rs.tpl
@@ -14,18 +14,25 @@ fn part2(input: &str) -> String {
     todo!()
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn part1_example() {
-        assert_eq!(part1(&parse("<EXAMPLE>")), "<RESULT>");
+        let input = "";
+        let output = "";
+
+        let input = parse(input);
+        assert_eq!(part1(input), output);
     }
 
     #[test]
     fn part2_example() {
-        assert_eq!(part2(&parse("<EXAMPLE>")), "<RESULT>");
+        let input = "";
+        let output = "";
+
+        let input = parse(input);
+        assert_eq!(part2(input), output);
     }
 }


### PR DESCRIPTION
This slightly improves the boilerplate gen. I think that cargo-aoc users always want the two tests that come for free
