### PR TITLE
[FEAT] Use incremental builds and lto=false for release by default

### DIFF
--- a/cargo-aoc/src/app.rs
+++ b/cargo-aoc/src/app.rs
@@ -259,7 +259,7 @@ impl AOCApp {
         .replace(
             "{PROFILE}",
             if args.is_present("profile") {
-                "[profile.release]\ndebug = true"
+                "debug = true\n"
             } else {
                 ""
             },

--- a/cargo-aoc/template/Cargo-run.toml.tpl
+++ b/cargo-aoc/template/Cargo-run.toml.tpl
@@ -7,4 +7,7 @@ authors = ["Grégory Obanos <gregory.obanos@gmail.com>"]
 {CRATE_NAME} = { path = "../../.." }
 aoc-runner = "0.2.2"
 
+[profile.release]
+incremental = true
+lto = false
 {PROFILE}


### PR DESCRIPTION
This change makes all release profile builds use incremental and lto=false to limit the amount of time it takes to run an individual day. When given `--profile`, it will add the debug symbols as previously expected.

Background:

As I was working on AoC 2023, the more days that I completed the longer each invocation of `cargo aoc` would take to run. It eventually got to be nearly 2 minutes in length. I have tweaked the template to always enable incremental builds and to minimize link time optimization to just the current crate in order to reduce build times. For reference, once I rebuilt my current project with the modified `cargo-aoc` I was able to get my build times down to 5-6 seconds.