### PR TITLE
[Cargo.toml][tokio] Switch to rt-multi-thread feature on tokio

### DIFF
--- a/cargo-aoc/Cargo.toml
+++ b/cargo-aoc/Cargo.toml
@@ -20,4 +20,4 @@ reqwest = { version = "0.11.22", default-features = false, features = ["blocking
 webbrowser = "0.8.12"
 directories = "5.0.1"
 clap = { version = "4.4.8", features = ["derive"] }
-tokio = { version = "1.34.0", features = ["rt"] }
+tokio = { version = "1.34.0", features = ["rt-multi-thread"] }


### PR DESCRIPTION
I am getting following error when trying to instal from crates.io

`$ cargo install cargo-aoc`

(note that cargo install ignores the lock file so newer tokio is installed than on cargo build https://github.com/rust-lang/cargo/issues/7169 )

```
    Updating crates.io index
  Installing cargo-aoc v0.3.7
    Updating crates.io index
…
   Compiling tokio v1.38.0
…
   Compiling cargo-aoc v0.3.7
error[E0599]: no function or associated item named `new` found for struct `Runtime` in the current scope
   --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-aoc-0.3.7/src/app.rs:61:47
    |
61  |             let rt = tokio::runtime::Runtime::new().unwrap();
    |                                               ^^^ function or associated item not found in `Runtime`
    |
note: if you're trying to build a new `Runtime`, consider using `Runtime::from_parts` which returns `Runtime`
   --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.38.0/src/runtime/runtime.rs:138:5
    |
138 | /     pub(super) fn from_parts(
139 | |         scheduler: Scheduler,
140 | |         handle: Handle,
141 | |         blocking_pool: BlockingPool,
142 | |     ) -> Runtime {
    | |________________^

For more information about this error, try `rustc --explain E0599`.
error: could not compile `cargo-aoc` (bin "cargo-aoc") due to 1 previous error
error: failed to compile `cargo-aoc v0.3.7`, intermediate artifacts can be found at `/tmp/cargo-installYFL5GA`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```

Using the rt-multi-thread feature on tokio fixes the build.