### PR TITLE
Use tokio::runtime::Builder::new_current_thread

### DIFF
--- a/cargo-aoc/src/app.rs
+++ b/cargo-aoc/src/app.rs
@@ -58,7 +58,7 @@ pub fn execute_input(args: &Input) -> Result<(), Box<dyn Error>> {
             .year
             .expect("Need to specify a year to run cargo-aoc input --all");
         {
-            let rt = tokio::runtime::Runtime::new().unwrap();
+            let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
             rt.block_on(async {
                 let client = reqwest::Client::builder()
                     .default_headers(headers)


### PR DESCRIPTION
When using `cargo install cargo-aoc` cargo doesn’t use the `Cargo.lock` file (see https://github.com/rust-lang/cargo/issues/7169 ) and installs newer `tokio` which results in a build error of `cargo-aoc` as `tokio` has hidden the `Runtime::new` function under `rt-multi-thread` feature in this commit https://github.com/tokio-rs/tokio/commit/9ed595767d01c400955122d276b34ab52b3a6aab . 

This is the error I am seeing:
```

    Updating crates.io index
  Installing cargo-aoc v0.3.7
    Updating crates.io index
…
   Compiling tokio v1.38.0
…
   Compiling cargo-aoc v0.3.7
error[E0599]: no function or associated item named `new` found for struct `Runtime` in the current scope
   --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-aoc-0.3.7/src/app.rs:61:47
    |
61  |             let rt = tokio::runtime::Runtime::new().unwrap();
    |                                               ^^^ function or associated item not found in `Runtime`
    |
note: if you're trying to build a new `Runtime`, consider using `Runtime::from_parts` which returns `Runtime`
   --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.38.0/src/runtime/runtime.rs:138:5
    |
138 | /     pub(super) fn from_parts(
139 | |         scheduler: Scheduler,
140 | |         handle: Handle,
141 | |         blocking_pool: BlockingPool,
142 | |     ) -> Runtime {
    | |________________^

For more information about this error, try `rustc --explain E0599`.
error: could not compile `cargo-aoc` (bin "cargo-aoc") due to 1 previous error
…
```

Using `tokio::runtime::Builder::new_current_thread` to create the runtime fixes the build error.

Tested by running
```
cargo-aoc    $ cargo install —path cargo-aoc

myaocrepo  $ cargo aoc credentials $TOKEN
myaocrepo  $ cargo aoc input -d 2023 -d 23
```
 